### PR TITLE
Migrate history storage to SQLite

### DIFF
--- a/ansiblePower.py
+++ b/ansiblePower.py
@@ -2,6 +2,7 @@
 """AnsiblePower — Lightweight web interface for managing Ansible playbooks."""
 import os
 import json
+import sqlite3
 import shutil
 import subprocess
 import psutil
@@ -105,22 +106,124 @@ def get_hosts_file():
     config = load_config()
     return config.get("hosts_file", HOSTS_FILE)
 
+def get_history_db_file():
+    """Return the SQLite database path for playbook history."""
+    return os.path.splitext(HISTORY_FILE)[0] + ".db"
+
+
+def get_history_db_connection():
+    """Create a SQLite connection for history storage."""
+    history_db_file = get_history_db_file()
+    history_dir = os.path.dirname(history_db_file)
+
+    if history_dir and not os.path.exists(history_dir):
+        os.makedirs(history_dir)
+
+    conn = sqlite3.connect(history_db_file)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _history_records_to_rows(history):
+    """Convert history dictionaries to SQLite insert rows."""
+    return [
+        (
+            record.get("action", ""),
+            record.get("playbook", ""),
+            record.get("output", ""),
+            record.get("time", "")
+        )
+        for record in history
+        if isinstance(record, dict)
+    ]
+
+
+def init_history_db():
+    """Initialize SQLite history storage and migrate existing JSON history."""
+    try:
+        with get_history_db_connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS playbook_runs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    action TEXT NOT NULL,
+                    playbook TEXT NOT NULL,
+                    output TEXT NOT NULL,
+                    time TEXT NOT NULL
+                )
+            """)
+
+            row_count = conn.execute(
+                "SELECT COUNT(*) FROM playbook_runs"
+            ).fetchone()[0]
+
+            if row_count == 0 and os.path.exists(HISTORY_FILE):
+                try:
+                    with open(HISTORY_FILE, "r") as f:
+                        history = json.load(f)
+
+                    if isinstance(history, list):
+                        conn.executemany("""
+                            INSERT INTO playbook_runs
+                            (action, playbook, output, time)
+                            VALUES (?, ?, ?, ?)
+                        """, _history_records_to_rows(history))
+                        logger.info("Migrated existing history.json records to SQLite")
+                except Exception as e:
+                    logger.error("Error migrating history.json to SQLite: %s", e)
+    except Exception as e:
+        logger.error("Error initializing history database: %s", e)
+
+
 def load_history():
-    if os.path.exists(HISTORY_FILE):
-        with open(HISTORY_FILE, "r") as f:
-            try:
-                return json.load(f)
-            except Exception as e:
-                logger.error("Error loading history: %s", e)
-                return []
-    return []
+    """Load playbook run history from SQLite as a list of dictionaries."""
+    try:
+        init_history_db()
+
+        with get_history_db_connection() as conn:
+            rows = conn.execute("""
+                SELECT action, playbook, output, time
+                FROM playbook_runs
+                ORDER BY id ASC
+            """).fetchall()
+
+        return [dict(row) for row in rows]
+    except Exception as e:
+        logger.error("Error loading history from SQLite: %s", e)
+        return []
+
 
 def save_history(history):
+    """Replace playbook run history in SQLite with the provided records."""
     try:
-        with open(HISTORY_FILE, "w") as f:
-            json.dump(history, f, indent=2)
+        init_history_db()
+
+        with get_history_db_connection() as conn:
+            conn.execute("DELETE FROM playbook_runs")
+            conn.executemany("""
+                INSERT INTO playbook_runs (action, playbook, output, time)
+                VALUES (?, ?, ?, ?)
+            """, _history_records_to_rows(history))
     except Exception as e:
-        logger.error("Error saving history: %s", e)
+        logger.error("Error saving history to SQLite: %s", e)
+
+
+def add_history_record(record):
+    """Insert a single playbook run history record into SQLite."""
+    try:
+        init_history_db()
+
+        with get_history_db_connection() as conn:
+            conn.execute("""
+                INSERT INTO playbook_runs (action, playbook, output, time)
+                VALUES (?, ?, ?, ?)
+            """, (
+                record.get("action", ""),
+                record.get("playbook", ""),
+                record.get("output", ""),
+                record.get("time", "")
+            ))
+    except Exception as e:
+        logger.error("Error adding history record to SQLite: %s", e)
 
 # =============================================================================
 # Flask App Setup
@@ -218,14 +321,12 @@ def run_playbook():
     if not output.strip():
         output = "No output produced."
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    history = load_history()
-    history.append({
+    add_history_record({
         "action": "run",
         "playbook": playbook_name,
         "output": output,
         "time": timestamp
     })
-    save_history(history)
     logger.info("Recorded playbook run: %s", playbook_name)
     return jsonify({"output": output})
 
@@ -469,8 +570,7 @@ def _ensure_dirs():
         sample_playbook = os.path.join(DEFAULT_PLAYBOOKS_DIR, "sample.yml")
         with open(sample_playbook, "w") as f:
             f.write("---\n# Sample Ansible Playbook\n- name: Sample playbook\n  hosts: all\n  tasks:\n    - name: Print hello message\n      debug:\n        msg: \"Hello from AnsiblePower!\"\n")
-    if not os.path.exists(HISTORY_FILE):
-        save_history([])
+    init_history_db()
     if not os.path.exists(CONFIG_FILE):
         save_config({"playbooks_dir": DEFAULT_PLAYBOOKS_DIR, "hosts_file": HOSTS_FILE})
     hosts_file_path = get_hosts_file()

--- a/tests/ut_ansiblePower.py
+++ b/tests/ut_ansiblePower.py
@@ -6,7 +6,15 @@ from unittest.mock import patch, mock_open
 
 # Add parent directory to path to import ansiblePower
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from ansiblePower import load_config, save_config, load_history, save_history
+
+from ansiblePower import (
+    get_history_db_file,
+    load_config,
+    load_history,
+    save_config,
+    save_history,
+)
+
 
 class TestConfigAndHistory(unittest.TestCase):
 
@@ -14,14 +22,21 @@ class TestConfigAndHistory(unittest.TestCase):
         # Set up temporary file paths for testing
         self.test_config_file = "test_config.json"
         self.test_history_file = "test_history.json"
+        self.test_history_db_file = "test_history.db"
         self.default_playbooks_dir = "/path/to/default/playbooks"
+
         # Patch the constants in the original module
-        patcher_config = patch('ansiblePower.CONFIG_FILE', self.test_config_file)
-        patcher_history = patch('ansiblePower.HISTORY_FILE', self.test_history_file)
-        patcher_default_dir = patch('ansiblePower.DEFAULT_PLAYBOOKS_DIR', self.default_playbooks_dir)
+        patcher_config = patch("ansiblePower.CONFIG_FILE", self.test_config_file)
+        patcher_history = patch("ansiblePower.HISTORY_FILE", self.test_history_file)
+        patcher_default_dir = patch(
+            "ansiblePower.DEFAULT_PLAYBOOKS_DIR",
+            self.default_playbooks_dir,
+        )
+
         self.mock_config = patcher_config.start()
         self.mock_history = patcher_history.start()
         self.mock_default_dir = patcher_default_dir.start()
+
         self.addCleanup(patcher_config.stop)
         self.addCleanup(patcher_history.stop)
         self.addCleanup(patcher_default_dir.stop)
@@ -31,6 +46,8 @@ class TestConfigAndHistory(unittest.TestCase):
             os.remove(self.test_config_file)
         if os.path.exists(self.test_history_file):
             os.remove(self.test_history_file)
+        if os.path.exists(self.test_history_db_file):
+            os.remove(self.test_history_db_file)
 
     def tearDown(self):
         # Clean up test files after each test
@@ -38,12 +55,15 @@ class TestConfigAndHistory(unittest.TestCase):
             os.remove(self.test_config_file)
         if os.path.exists(self.test_history_file):
             os.remove(self.test_history_file)
+        if os.path.exists(self.test_history_db_file):
+            os.remove(self.test_history_db_file)
 
     # Test load_config
     def test_load_config_existing_valid(self):
         config_data = {"playbooks_dir": "/path/to/playbooks"}
         with open(self.test_config_file, "w") as f:
             json.dump(config_data, f)
+
         self.assertEqual(load_config(), config_data)
 
     def test_load_config_file_not_found(self):
@@ -52,30 +72,47 @@ class TestConfigAndHistory(unittest.TestCase):
     def test_load_config_invalid_json(self):
         with open(self.test_config_file, "w") as f:
             f.write("invalid json")
+
         self.assertEqual(load_config(), {"playbooks_dir": self.default_playbooks_dir})
 
     # Test save_config
     def test_save_config_success(self):
         config_data = {"playbooks_dir": "/new/path"}
         save_config(config_data)
+
         self.assertTrue(os.path.exists(self.test_config_file))
+
         with open(self.test_config_file, "r") as f:
             loaded_config = json.load(f)
+
         self.assertEqual(loaded_config, config_data)
 
-    @patch('ansiblePower.open', new_callable=mock_open)
+    @patch("ansiblePower.open", new_callable=mock_open)
     def test_save_config_write_error(self, mock_file):
         mock_file.side_effect = IOError("Permission denied")
         config_data = {"playbooks_dir": "/new/path"}
-        with self.assertLogs('ansiblePower', level='ERROR') as cm:
+
+        with self.assertLogs("ansiblePower", level="ERROR") as cm:
             save_config(config_data)
+
         self.assertIn("Error saving config:", cm.output[0])
 
-    # Test load_history
+    # Test SQLite history helpers
+    def test_get_history_db_file_uses_history_file_path(self):
+        self.assertEqual(get_history_db_file(), "test_history.db")
+
     def test_load_history_existing_valid(self):
-        history_data = [{"action": "run", "playbook": "test.yml", "time": "now", "output": "success"}]
-        with open(self.test_history_file, "w") as f:
-            json.dump(history_data, f)
+        history_data = [
+            {
+                "action": "run",
+                "playbook": "test.yml",
+                "time": "now",
+                "output": "success",
+            }
+        ]
+
+        save_history(history_data)
+
         self.assertEqual(load_history(), history_data)
 
     def test_load_history_file_not_found(self):
@@ -84,24 +121,36 @@ class TestConfigAndHistory(unittest.TestCase):
     def test_load_history_invalid_json(self):
         with open(self.test_history_file, "w") as f:
             f.write("invalid json history")
+
         self.assertEqual(load_history(), [])
 
-    # Test save_history
     def test_save_history_success(self):
-        history_data = [{"action": "show", "playbook": "other.yml", "time": "later", "output": "content"}]
+        history_data = [
+            {
+                "action": "show",
+                "playbook": "other.yml",
+                "time": "later",
+                "output": "content",
+            }
+        ]
+
         save_history(history_data)
-        self.assertTrue(os.path.exists(self.test_history_file))
-        with open(self.test_history_file, "r") as f:
-            loaded_history = json.load(f)
-        self.assertEqual(loaded_history, history_data)
 
-    @patch('ansiblePower.open', new_callable=mock_open)
-    def test_save_history_write_error(self, mock_file):
-        mock_file.side_effect = IOError("Disk full")
+        self.assertTrue(os.path.exists(self.test_history_db_file))
+        self.assertEqual(load_history(), history_data)
+
+    @patch("ansiblePower.sqlite3.connect")
+    def test_save_history_write_error(self, mock_connect):
+        mock_connect.side_effect = OSError("Disk full")
         history_data = [{"action": "save", "playbook": "fail.yml"}]
-        with self.assertLogs('ansiblePower', level='ERROR') as cm:
-            save_history(history_data)
-        self.assertIn("Error saving history:", cm.output[0])
 
-if __name__ == '__main__':
+        with self.assertLogs("ansiblePower", level="ERROR") as cm:
+            save_history(history_data)
+
+        self.assertTrue(
+            any("Error saving history to SQLite:" in message for message in cm.output)
+        )
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Migrates playbook run history storage from the flat JSON file `data/history.json` to an SQLite database.

This PR adds SQLite-backed history helpers while preserving the existing history data shape used by the UI and import/export endpoints. New playbook run records are inserted directly into SQLite instead of reading and rewriting the entire history list.

The migration keeps JSON/CSV import and export behavior compatible by continuing to return and accept the same list-of-dictionaries schema:

- `action`
- `playbook`
- `output`
- `time`

Fixes #27

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manual validation performed:

- Verified that the app initializes a SQLite history database
- Verified that the `playbook_runs` table is created if it does not exist
- Verified that existing `history.json` records can be migrated into SQLite
- Verified that new playbook run records are inserted into SQLite
- Verified that `load_history()` returns the existing list-of-dictionaries structure expected by the history page
- Verified that JSON export still returns the standard history schema
- Verified that CSV export still returns the standard history schema
- Verified that JSON/CSV import still parses records and stores them in SQLite

- [ ] `pytest tests/` (Local unit tests pass)
- [ ] Docker build passes locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes